### PR TITLE
Make setting jvmOptions a TaskKey

### DIFF
--- a/src/main/scala/com/typesafe/sbt/SbtMultiJvm.scala
+++ b/src/main/scala/com/typesafe/sbt/SbtMultiJvm.scala
@@ -34,7 +34,7 @@ object SbtMultiJvm extends Plugin {
 
     val java = TaskKey[File]("java")
 
-    val jvmOptions = SettingKey[Seq[String]]("jvm-options")
+    val jvmOptions = TaskKey[Seq[String]]("jvm-options")
     val extraOptions = SettingKey[String => Seq[String]]("extra-options")
 
     val scalatestRunner = SettingKey[String]("scalatest-runner")


### PR DESCRIPTION
This allow something like each run of the test to check for the environment and set some options to nodes

This enable something like starting a kafka server from sbt in a sbt docker, getting its dynamic port binding, and setting it to the nodes

kafkaStart in MultiJvm <<= Infra.Keys.kafkaStart runBefore (MultiJvmKeys.jvmOptions in MultiJvm)

kafkaStop in MultiJvm <<= Infra.Keys.kafkaStop triggeredBy (test in Test)

MultiJvmKeys.jvmOptions in MultiJvm := {
  Infra.Settings.kafkaPortMappings((baseDirectory in ThisProject).value / ".kafka").map {
    case (port, mapping) =>
      s"-Dkafka.$port=$mapping"
  }.toSeq ++ Seq(s"-Dkafka.host=${Infra.Keys.boot2docker_ip.value}")